### PR TITLE
Fix: Crypto lib is missing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,6 @@
 import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
 import * as querystring from 'querystring';
-import * as crypto from 'crypto';
 import axios from 'axios';
 import { Octokit } from '@octokit/rest';
 import { pick } from 'lodash';
@@ -31,6 +30,7 @@ const authorize = ({
   rawBody,
   headers: { 'X-Slack-Signature': signature, 'X-Slack-Request-Timestamp': timestamp }
 }) => {
+  const crypto = require('crypto'); // <= moved inside
   const version = 'v0';
   const basestring = `${version}:${timestamp}:${rawBody}`;
   const hash = crypto.createHmac('sha256', slackSigningSecret).update(basestring).digest('hex');


### PR DESCRIPTION
The SAGA lambda execution failed on 
```
  | 2025-07-21T10:23:32.819Z2025-07-21T10:23:32.819Z	54bd0211-e38a-41ea-bce8-4b57d9c3b8a0	ERROR	Invoke Error 	{     "errorType": "ReferenceError",     "errorMessage": "crypto is not defined",     "stack": [         "ReferenceError: crypto is not defined",         "    at Object.<anonymous> (/var/task/__index.js:28:18)",         "    at Object.__f2 [as authorize] (/var/task/__index.js:35:34)",         "    at /var/task/__index.js:44:21",         "    at Generator.next (<anonymous>)",         "    at /var/task/__index.js:13:71",         "    at new Promise (<anonymous>)",         "    at Object.<anonymous> (/var/task/__index.js:9:12)",         "    at Object.__f1 [as __awaiter] (/var/task/__index.js:18:34)",         "    at Runtime.<anonymous> (/var/task/__index.js:42:40)",         "    at Runtime.__f0 [as handler] (/var/task/__index.js:71:34)"     ] }
-- | --
```

Solution:

- Pulumi serializes the callback function and uploads it as a string to Lambda. When doing so, it does not bring in top-level import statements, meaning modules like crypto aren’t defined
- import it inside `CallbackFunction`

